### PR TITLE
简单支持双屏

### DIFF
--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -18,7 +18,7 @@ pub fn capture_absolute(
         height,
     }: &PixelRect,
 ) -> Result<RgbImage, String> {
-    let screen = screenshots::Screen::all().expect("cannot get DisplayInfo")[0];
+    let screen = screenshots::Screen::from_point(0, 0).expect("cannot get DisplayInfo");
     let png_img = screen
         .capture_area(*left, *top, *width as u32, *height as u32)
         .expect("capture failed");
@@ -54,9 +54,9 @@ pub fn capture_absolute_image(
         height,
     }: &PixelRect,
 ) -> Result<image::RgbImage, String> {
-    // simply use the first screen.
+    // simply use the main screen (from 0,0) to support multi-screen.
     // todo: multi-screen support
-    let screen = screenshots::Screen::all().expect("cannot get DisplayInfo")[0];
+    let screen = screenshots::Screen::from_point(0, 0).expect("cannot get DisplayInfo");
     let image = screen
         .capture_area(*left, *top, *width as u32, *height as u32)
         .expect("capture failed");


### PR DESCRIPTION
就是把截图第一个屏幕改成从0,0截图，0,0就是主屏的左上角
全屏模式或者窗口化模式可以用win+shift+↑↓←→移动到主屏，不会卡顿，这个是多屏用户基操了

不知道from0,0是从0,0把右下角的所有屏幕都截了还是从0,0截取0,0所在屏幕
可能出现特别多屏然后从主屏截会截图太大？。。我只有两个屏幕

至少不用去win+i改显示器设置。。
windows全屏和窗口化都试了试没问题能用，linux不知道

也许可以看看screenshot-rs里all函数返回的那个数组怎么划分的0123，然后看看这边能不能学一下